### PR TITLE
⚡ Bolt: Optimize simulation loop to reduce 20Hz re-renders

### DIFF
--- a/src/components/NeuroEmSimulator.tsx
+++ b/src/components/NeuroEmSimulator.tsx
@@ -106,11 +106,7 @@ const BrainModel = ({ activityLevels }: { activityLevels: Record<BrainRegionName
 
 // --- Main Component ---
 
-interface NeuroEmSimulatorProps {
-  bioResonanceFrequency: number;
-}
-
-export const NeuroEmSimulator: React.FC<NeuroEmSimulatorProps> = ({ bioResonanceFrequency }) => {
+export const NeuroEmSimulator = React.memo(() => {
   const [frequency, setFrequency] = useState(10); // Hz
   const [amplitude, setAmplitude] = useState(0.5); // 0 to 1
   const [waveform, setWaveform] = useState('sine'); // sine, square, sawtooth
@@ -198,4 +194,4 @@ export const NeuroEmSimulator: React.FC<NeuroEmSimulatorProps> = ({ bioResonance
       </div>
     </div>
   );
-};
+});

--- a/src/components/PegasusSimulation.tsx
+++ b/src/components/PegasusSimulation.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { TacticalDataDisplay } from './TacticalDataDisplay';
+import { TacticalDataDisplay as RawTacticalDataDisplay } from './TacticalDataDisplay';
 import { OperatorVitalsCognitiveLoadMonitor } from './OperatorVitalsCognitiveLoadMonitor';
-import { SitRepIntelFeed } from './SitRepIntelFeed';
-import { TouchInterface } from './TouchInterface';
-import { DecisionMatrixSimulator } from './DecisionMatrixSimulator';
+import { SitRepIntelFeed as RawSitRepIntelFeed } from './SitRepIntelFeed';
+import { TouchInterface as RawTouchInterface } from './TouchInterface';
+import { DecisionMatrixSimulator as RawDecisionMatrixSimulator } from './DecisionMatrixSimulator';
 import { TemporalArchive } from './TemporalArchive';
-import { SquadCohesionIndex } from './SquadCohesionIndex';
-import { MissionCriticalEventRecorder } from './MissionCriticalEventRecorder';
+import { SquadCohesionIndex as RawSquadCohesionIndex } from './SquadCohesionIndex';
+import { MissionCriticalEventRecorder as RawMissionCriticalEventRecorder } from './MissionCriticalEventRecorder';
 import { StatusIndicators } from './StatusIndicators';
 import { HeaderStatusBar } from './HeaderStatusBar';
 import { MobileHeader } from './MobileHeader';
@@ -18,6 +18,16 @@ import { useRedTeamSimulation } from '../hooks/useRedTeamSimulation';
 import { NeuroEmSimulator } from './NeuroEmSimulator';
 import { Button } from './ui/button';
 import { dataGenerator } from '../data/realisticData';
+
+const TacticalDataDisplay = React.memo(RawTacticalDataDisplay);
+const SitRepIntelFeed = React.memo(RawSitRepIntelFeed);
+const TouchInterface = React.memo(RawTouchInterface);
+const DecisionMatrixSimulator = React.memo(RawDecisionMatrixSimulator);
+const SquadCohesionIndex = React.memo(RawSquadCohesionIndex);
+const MissionCriticalEventRecorder = React.memo(RawMissionCriticalEventRecorder);
+
+const EMPTY_LIST = [];
+const NO_OP = () => {};
 
 interface PegasusSimulationProps {
   accessLevel: number;
@@ -221,11 +231,11 @@ export const PegasusSimulation: React.FC<PegasusSimulationProps> = ({
           {/* Center Top - Decision Matrix Simulator or Tactical Data Display */}
           <div className="col-span-6 row-span-3">
             {showElectrokineticLayer ? (
-              <NeuroEmSimulator bioResonanceFrequency={bioResonanceFrequency} />
+              <NeuroEmSimulator />
             ) : simulationMode ? (
               <DecisionMatrixSimulator
-                decisionPoints={[]}
-                onOutcomeSelect={() => {}}
+                decisionPoints={EMPTY_LIST}
+                onOutcomeSelect={NO_OP}
               />
             ) : (
               <TacticalDataDisplay
@@ -265,8 +275,8 @@ export const PegasusSimulation: React.FC<PegasusSimulationProps> = ({
           {/* Right Panel Bottom - Mission Critical Event Recorder */}
           <div className="col-span-3 row-span-3">
             <MissionCriticalEventRecorder
-              snapshots={[]}
-              onSnapshotSelect={() => {}}
+              snapshots={EMPTY_LIST}
+              onSnapshotSelect={NO_OP}
             />
           </div>
 
@@ -297,11 +307,11 @@ export const PegasusSimulation: React.FC<PegasusSimulationProps> = ({
           {/* Mobile Main Visualizer */}
           <div className="flex-1 min-h-[40vh]">
             {showElectrokineticLayer ? (
-              <NeuroEmSimulator bioResonanceFrequency={bioResonanceFrequency} />
+              <NeuroEmSimulator />
             ) : simulationMode ? (
               <DecisionMatrixSimulator
-                decisionPoints={[]}
-                onOutcomeSelect={() => {}}
+                decisionPoints={EMPTY_LIST}
+                onOutcomeSelect={NO_OP}
               />
             ) : (
               <TacticalDataDisplay
@@ -338,8 +348,8 @@ export const PegasusSimulation: React.FC<PegasusSimulationProps> = ({
               onFrequencyChange={setBioResonanceFrequency}
             />
             <MissionCriticalEventRecorder
-              snapshots={[]}
-              onSnapshotSelect={() => {}}
+              snapshots={EMPTY_LIST}
+              onSnapshotSelect={NO_OP}
             />
           </div>
 

--- a/src/hooks/useInteractionState.ts
+++ b/src/hooks/useInteractionState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 interface InteractionEvent {
   x: number;
@@ -25,14 +25,14 @@ export const useInteractionState = (): InteractionStateResult => {
   const [cohesionScore, setCohesionScore] = useState(0);
   const [bioResonanceFrequency, setBioResonanceFrequency] = useState(40);
 
-  const addInteractionEvent = (event: InteractionEvent) => {
+  const addInteractionEvent = useCallback((event: InteractionEvent) => {
     setInteractionEvents(prev => [...prev.slice(-4), event]);
-  };
+  }, []);
 
-  const handleTemporalShift = (timeline: number, moment: number) => {
+  const handleTemporalShift = useCallback((timeline: number, moment: number) => {
     setCurrentTimeline(timeline);
     setTemporalMoment(moment);
-  };
+  }, []);
 
   return {
     interactionEvents,

--- a/verify_simulation.py
+++ b/verify_simulation.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+import time
+
+def verify_simulation():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            print("Navigating to http://localhost:8080")
+            page.goto("http://localhost:8080")
+
+            # Wait for some content to load
+            print("Waiting for content...")
+            # Using a more generic selector or text that should be present
+            page.wait_for_selector("body", timeout=30000)
+
+            # Wait a bit more for React to hydrate and render
+            time.sleep(5)
+
+            # Take screenshot
+            print("Taking screenshot...")
+            page.screenshot(path="/home/jules/verification/simulation.png")
+            print("Screenshot taken")
+
+        except Exception as e:
+            print(f"Error: {e}")
+            try:
+                page.screenshot(path="/home/jules/verification/error.png")
+            except:
+                pass
+        finally:
+            browser.close()
+
+if __name__ == "__main__":
+    verify_simulation()


### PR DESCRIPTION
⚡ Bolt: Optimize simulation loop to reduce 20Hz re-renders

💡 **What:**
- Wrapped `addInteractionEvent` and `handleTemporalShift` in `useCallback` in `useInteractionState.ts`.
- Removed `bioResonanceFrequency` prop from `NeuroEmSimulator` in `NeuroEmSimulator.tsx`.
- Wrapped `NeuroEmSimulator`, `TacticalDataDisplay`, `SquadCohesionIndex`, `SitRepIntelFeed`, `MissionCriticalEventRecorder`, `DecisionMatrixSimulator`, `TouchInterface` in `React.memo` inside `PegasusSimulation.tsx`.
- Introduced `EMPTY_LIST` and `NO_OP` constants for stable props.

🎯 **Why:**
- The `PegasusSimulation` component re-renders at ~20Hz due to `audioLevel`/`bioResonanceFrequency` updates from `useAudioAnalysis`.
- This was causing all child components to re-render, even heavy ones like `NeuroEmSimulator` (3D canvas) and `TacticalDataDisplay` (2D canvas), which didn't need the updates.
- `NeuroEmSimulator` was receiving `bioResonanceFrequency` but not using it, forcing re-renders.
- `MissionCriticalEventRecorder` was receiving new `[]` and `() => {}` references every render, breaking any potential memoization.

📊 **Impact:**
- Eliminates unnecessary re-renders of heavy visualization components (Canvas/3D).
- Reduces main thread blocking time.
- Improves battery life and responsiveness on lower-end devices.

🔬 **Measurement:**
- Verified frontend functionality via Playwright screenshot.
- Confirmed tests pass.
- Code review confirms memoization pattern and hook stability.

---
*PR created automatically by Jules for task [10974096557854110459](https://jules.google.com/task/10974096557854110459) started by @topherchris420*